### PR TITLE
Improvements for Pathfinding PR

### DIFF
--- a/libs/s25main/Ware.cpp
+++ b/libs/s25main/Ware.cpp
@@ -338,7 +338,7 @@ unsigned Ware::CheckNewGoalForLostWare(const noBaseBuilding& newgoal) const
 Ware::RouteParams Ware::CalcPathToGoal(const noBaseBuilding& newgoal) const
 {
     RTTR_Assert(location);
-    unsigned length = 0xFFFFFFFF;
+    unsigned length;
     RoadPathDirection possibledir = world->FindPathForWareOnRoads(*location, newgoal, &length);
     if(possibledir != RoadPathDirection::None) // there is a valid path to the goal? -> ordered!
     {
@@ -346,19 +346,17 @@ Ware::RouteParams Ware::CalcPathToGoal(const noBaseBuilding& newgoal) const
         // because non-warehouses cannot just carry in new wares they need a helper to do this
         if(possibledir == RoadPathDirection::NorthWest && newgoal.GetFlagPos() == location->GetPos())
         {
+            // Not executed for road from flag to the warehouse as that is handled directly by the warehouse
+            RTTR_Assert(!BuildingProperties::IsWareHouse(newgoal.GetBuildingType()));
             for(const auto dir : helpers::EnumRange<Direction>{})
             {
+                // Bounce of in this direction
                 if(dir != Direction::NorthWest && location->GetRoute(dir))
-                {
-                    possibledir = toRoadPathDirection(dir);
-                    break;
-                }
+                    return {1, toRoadPathDirection(dir)};
             }
-            if(possibledir == RoadPathDirection::NorthWest) // got no other route from the flag -> impossible
-                return {0xFFFFFFFF, RoadPathDirection::None};
+            // got no other route from the flag -> impossible
+            return {0xFFFFFFFF, RoadPathDirection::None};
         }
-        // at this point there either is a road to the goal
-        // or we are at the flag of the goal and have a road to a different flag to bounce off of to get to the goal
         return {length, possibledir};
     }
     return {0xFFFFFFFF, RoadPathDirection::None};

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -839,9 +839,9 @@ std::vector<nobHarborBuilding::ShipConnection> nobHarborBuilding::GetShipConnect
     {
         ShipConnection sc;
         sc.dest = harbor_building;
-        // Als Kantengewicht nehmen wir die doppelte Entfernung (evtl muss ja das Schiff erst kommen)
-        // plus einer Kopfpauschale (Ein/Ausladen usw. dauert ja alles)
-        sc.way_costs = 2 * world->CalcHarborDistance(GetHarborPosID(), harbor_building->GetHarborPosID()) + 10;
+        // Use twice the distance as cost (ship might need to arrive first) and a fixed value to represent
+        // loading&unloading
+        sc.way_costs = 2 * world->CalcHarborDistance(GetHarborPosID(), harbor_building->GetHarborPosID()) + 510;
         connections.push_back(sc);
     }
     return connections;

--- a/libs/s25main/buildings/nobHarborBuilding.cpp
+++ b/libs/s25main/buildings/nobHarborBuilding.cpp
@@ -841,7 +841,7 @@ std::vector<nobHarborBuilding::ShipConnection> nobHarborBuilding::GetShipConnect
         sc.dest = harbor_building;
         // Use twice the distance as cost (ship might need to arrive first) and a fixed value to represent
         // loading&unloading
-        sc.way_costs = 2 * world->CalcHarborDistance(GetHarborPosID(), harbor_building->GetHarborPosID()) + 510;
+        sc.way_costs = 2 * world->CalcHarborDistance(GetHarborPosID(), harbor_building->GetHarborPosID()) + 10;
         connections.push_back(sc);
     }
     return connections;

--- a/libs/s25main/nodeObjs/noFlag.cpp
+++ b/libs/s25main/nodeObjs/noFlag.cpp
@@ -232,8 +232,6 @@ unsigned noFlag::GetPunishmentPoints(const Direction dir) const
 {
     constexpr auto PATHFINDING_PENALTY_CARRIER_ARRIVING = 50;
     constexpr auto PATHFINDING_PENALTY_NO_CARRIER = 500;
-    // This must be the same as "NO_CARRIER" for replay compatibility
-    constexpr auto PATHFINDING_PENALTY_START_SHIPPING = 500;
     // 2 Points per ware as carrier has to walk to other point and back for each ware
     unsigned points = GetNumWaresForRoad(dir) * 2;
 
@@ -248,12 +246,9 @@ unsigned noFlag::GetPunishmentPoints(const Direction dir) const
     {
         // Routes are either between flags or from a flag to a building, see the ctor of noBaseBuilding
         const bool isBuildingEntry = (dir == Direction::NorthWest) && (routeInDir->GetF2()->GetGOT() != GO_Type::Flag);
+        // For entering a building no carrier is required
         // Only roads to buildings considered by path finding are those to harbors
-        if(isBuildingEntry)
-        {
-            RTTR_Assert(routeInDir->GetF2()->GetGOT() == GO_Type::NobHarborbuilding);
-            points += PATHFINDING_PENALTY_START_SHIPPING;
-        } else
+        if(!isBuildingEntry)
             points += PATHFINDING_PENALTY_NO_CARRIER;
     }
 

--- a/libs/s25main/nodeObjs/noFlag.cpp
+++ b/libs/s25main/nodeObjs/noFlag.cpp
@@ -228,13 +228,13 @@ unsigned noFlag::GetNumWaresForRoad(const Direction dir) const
     return helpers::count_if(wares, [roadDir](const auto& ware) { return ware->GetNextDir() == roadDir; });
 }
 
-/**
- *  Gibt Wegstrafpunkte für das Pathfinden für Waren, die in eine bestimmte
- *  Richtung noch transportiert werden müssen.
- */
 unsigned noFlag::GetPunishmentPoints(const Direction dir) const
 {
-    // Waren zählen, die in diese Richtung transportiert werden müssen
+    constexpr auto PATHFINDING_PENALTY_CARRIER_ARRIVING = 50;
+    constexpr auto PATHFINDING_PENALTY_NO_CARRIER = 500;
+    // This must be the same as "NO_CARRIER" for replay compatibility
+    constexpr auto PATHFINDING_PENALTY_START_SHIPPING = 500;
+    // 2 Points per ware as carrier has to walk to other point and back for each ware
     unsigned points = GetNumWaresForRoad(dir) * 2;
 
     const RoadSegment* routeInDir = GetRoute(dir);
@@ -243,9 +243,19 @@ unsigned noFlag::GetPunishmentPoints(const Direction dir) const
     {
         // normal carrier has been ordered from the warehouse but has not yet arrived and no donkey
         if(humanCarrier->GetCarrierState() == CarrierState::FigureWork && !routeInDir->hasCarrier(1))
-            points += 50;
+            points += PATHFINDING_PENALTY_CARRIER_ARRIVING;
     } else if(!routeInDir->hasCarrier(1))
-        points += 500; // No carrier at all -> Large penalty
+    {
+        // Routes are either between flags or from a flag to a building, see the ctor of noBaseBuilding
+        const bool isBuildingEntry = (dir == Direction::NorthWest) && (routeInDir->GetF2()->GetGOT() != GO_Type::Flag);
+        // Only roads to buildings considered by path finding are those to harbors
+        if(isBuildingEntry)
+        {
+            RTTR_Assert(routeInDir->GetF2()->GetGOT() == GO_Type::NobHarborbuilding);
+            points += PATHFINDING_PENALTY_START_SHIPPING;
+        } else
+            points += PATHFINDING_PENALTY_NO_CARRIER;
+    }
 
     return points;
 }

--- a/libs/s25main/nodeObjs/noFlag.cpp
+++ b/libs/s25main/nodeObjs/noFlag.cpp
@@ -232,6 +232,9 @@ unsigned noFlag::GetPunishmentPoints(const Direction dir) const
 {
     constexpr auto PATHFINDING_PENALTY_CARRIER_ARRIVING = 50;
     constexpr auto PATHFINDING_PENALTY_NO_CARRIER = 500;
+    // This must be the same as "NO_CARRIER" for replay compatibility
+    // TODO(Replay): Move to `way_costs` in nobHarborBuilding::GetShipConnections
+    constexpr auto PATHFINDING_PENALTY_START_SHIPPING = 500;
     // 2 Points per ware as carrier has to walk to other point and back for each ware
     unsigned points = GetNumWaresForRoad(dir) * 2;
 
@@ -248,7 +251,11 @@ unsigned noFlag::GetPunishmentPoints(const Direction dir) const
         const bool isBuildingEntry = (dir == Direction::NorthWest) && (routeInDir->GetF2()->GetGOT() != GO_Type::Flag);
         // For entering a building no carrier is required
         // Only roads to buildings considered by path finding are those to harbors
-        if(!isBuildingEntry)
+        if(isBuildingEntry)
+        {
+            RTTR_Assert(routeInDir->GetF2()->GetGOT() == GO_Type::NobHarborbuilding);
+            points += PATHFINDING_PENALTY_START_SHIPPING;
+        } else
             points += PATHFINDING_PENALTY_NO_CARRIER;
     }
 

--- a/libs/s25main/nodeObjs/noFlag.h
+++ b/libs/s25main/nodeObjs/noFlag.h
@@ -46,8 +46,7 @@ public:
     std::unique_ptr<Ware> SelectWare(Direction roadDir, bool swap_wares, const noFigure* carrier);
     /// Prüft, ob es Waren gibt, die auf den Weg in Richtung dir getragen werden müssen.
     unsigned GetNumWaresForRoad(Direction dir) const;
-    /// Gibt Wegstrafpunkte für das Pathfinden für Waren, die in eine bestimmte Richtung noch transportiert werden
-    /// müssen.
+    /// Penalty for transporting a ware in a specific direction
     unsigned GetPunishmentPoints(Direction dir) const override;
     /// Zerstört evtl. vorhandenes Gebäude bzw. Baustelle vor der Flagge.
     void DestroyAttachedBuilding();

--- a/libs/s25main/pathfinding/RoadPathFinder.cpp
+++ b/libs/s25main/pathfinding/RoadPathFinder.cpp
@@ -125,6 +125,10 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
         return true;
     }
 
+    // If the goal is a flag (unlikely) we have no goal building
+    // TODO(Replay): Change RoadPathFinder::FindPath to target flag instead of building for wares
+    const noRoadNode* goalBld = (goal.GetGOT() == GO_Type::Flag) ? nullptr : &goal;
+
     // Use a counter for the visited-states so we don't have to reset them on every invocation
     currentVisit++;
     // if the counter reaches its maximum, tidy up
@@ -214,7 +218,7 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
             if(!isSegmentAllowed(*route))
                 continue;
 
-            const unsigned cost = best.cost + route->GetLength() + addCosts(best, dir);
+            const unsigned cost = best.cost + route->GetLength() + (neighbour != goalBld ? addCosts(best, dir) : 0);
 
             if(cost > max)
                 continue;

--- a/libs/s25main/pathfinding/RoadPathFinder.cpp
+++ b/libs/s25main/pathfinding/RoadPathFinder.cpp
@@ -150,8 +150,6 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
 
     todo.push(&start);
 
-    bool reachingDestViaAttachedFlag = false;
-
     while(!todo.empty())
     {
         // Get node with current least estimate
@@ -161,13 +159,7 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
         if(&best == &goal)
         {
             if(length)
-            {
                 *length = best.cost;
-                if(reachingDestViaAttachedFlag)
-                    *length += 500;
-                if(*length > max)
-                    return false;
-            }
 
             // Backtrack to get the last node that is not the start node (has a prev node)
             // --> Next node from start on path
@@ -224,21 +216,8 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
             unsigned add_cost = addCosts(best, dir);
 
             // special case: the road from a building to its flag does not need a carrier
-            if(dir == Direction::NorthWest && add_cost >= 500)
-            {
-                noBase* no = gwb_.GetNO(gwb_.GetNeighbour(best.GetPos(), dir));
-                if(no == &goal)
-                {
-                    if(no->GetType() == NodalObjectType::Buildingsite || no->GetType() == NodalObjectType::Building)
-                    {
-                        if((cost + add_cost) > max)
-                            return false;
-                        reachingDestViaAttachedFlag = true;
-                        RTTR_Assert(add_cost >= 500);
-                        add_cost -= 500;
-                    }
-                }
-            }
+            if(dir == Direction::NorthWest && add_cost >= 500 && neighbour == &goal && goal.GetGOT() != GO_Type::Flag)
+                add_cost -= 500;
             cost += add_cost;
 
             if(cost > max)

--- a/libs/s25main/pathfinding/RoadPathFinder.cpp
+++ b/libs/s25main/pathfinding/RoadPathFinder.cpp
@@ -125,10 +125,6 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
         return true;
     }
 
-    // If the goal is a flag (unlikely) we have no goal building
-    // TODO(Replay): Change RoadPathFinder::FindPath to target flag instead of building for wares
-    const noRoadNode* goalBld = (goal.GetGOT() == GO_Type::Flag) ? nullptr : &goal;
-
     // Use a counter for the visited-states so we don't have to reset them on every invocation
     currentVisit++;
     // if the counter reaches its maximum, tidy up
@@ -218,7 +214,7 @@ bool RoadPathFinder::FindPathImpl(const noRoadNode& start, const noRoadNode& goa
             if(!isSegmentAllowed(*route))
                 continue;
 
-            const unsigned cost = best.cost + route->GetLength() + (neighbour != goalBld ? addCosts(best, dir) : 0);
+            const unsigned cost = best.cost + route->GetLength() + addCosts(best, dir);
 
             if(cost > max)
                 continue;
@@ -299,6 +295,7 @@ bool RoadPathFinder::FindPath(const noRoadNode& start, const noRoadNode& goal, c
 
     if(wareMode)
     {
+        // TODO(Replay): Change to target flag instead of its attached building
         if(forbidden)
             return FindPathImpl(start, goal, max, AdditonalCosts::Carrier(),
                                 SegmentConstraints::AvoidSegment(forbidden), length, firstDir, firstNodePos);
@@ -323,6 +320,8 @@ bool RoadPathFinder::PathExists(const noRoadNode& start, const noRoadNode& goal,
 {
     if(allowWaterRoads)
     {
+        // TODO(Replay): Change to target flag instead of its attached building.
+        // Likely combine with RoadPathFinder::FindPath
         if(forbidden)
             return FindPathImpl(start, goal, max, AdditonalCosts::None(), SegmentConstraints::AvoidSegment(forbidden));
         else


### PR DESCRIPTION
Hi @wichern this is for your PR https://github.com/Return-To-The-Roots/s25client/pull/1734

You can ignore the first commit, that is just some non-functional changes I accumulated during testing.

What I wanted to improve upon your PR is to remove the re-addition of the 500 point penalty at the end of the pathfinding which shouldn't matter for the logic of the game which only uses the length to compare paths against each other to find the best. This was surprisingly easy without breaking the replays used by the tests.   
This resulted in a great simplification, see the 2nd commit.

Finally I wanted to avoid having knowledge about carriers and such in the path finder code especially the "does not need a carrier" and the constant `500` look questionable at this place, although they are (currently) correct.

The easiest way to avoid this is limiting pathfinding to the flag of the goal building, handle the additional distance of `1` "manually" and also the case where we start from the buildings flag. However the test replay showed a difference in the resulting paths in one case where the cost was the same (although one path used more flags) but as somewhere in-between a point was closer to the building than the flag and was handled first leading to the slightly different result (which is equivalent for the pathfinder).

So I haven't found a good way to implement this w/o breaking replays although I expect some better performance as every path need to end at the flag but the pathfinder doesn't know this and might consider more paths around the building than it has to.

Similar the penalty for entering a harbor shouldn't be there as there is shouldn't ever be a penalty for carrying a ware into a building. However removing that cost breaks the sea test replay as at one point using a ship becomes cheaper (381 instead of 581) than the alternative (454).    
I also tried moving that penalty from noFlag to the harbor building that returns shipconnections with associated costs. I had to revert that as it breaks the replay as moving a ware that is already in the harbor now gets more expensive.

So I just added a couple TODO notes that can be adressed when we have to break replays. I don't think it gets cleaner than this for now. What do you think?